### PR TITLE
Remove URI, CAT, JCI, CMI from data center portfolio

### DIFF
--- a/daily/daily_screen.py
+++ b/daily/daily_screen.py
@@ -26,15 +26,11 @@ THEMATIC_RULES = {
     "LEU":   {"sma": 100, "rsi": 45},
     "SMR":   {"sma": 100, "rsi": 45},
     "STRL":  {"sma": 100, "rsi": 45},   # Sterling Infrastructure
-    "URI":   {"sma": 100, "rsi": 45},   # United Rentals
-    "CAT":   {"sma": 100, "rsi": 45},   # Caterpillar
     "VRT":   {"sma": 100, "rsi": 45},   # Vertiv
     "ETN":   {"sma": 100, "rsi": 45},   # Eaton
-    "CMI":   {"sma": 100, "rsi": 45},   # Cummins
     "EME":   {"sma": 100, "rsi": 45},   # EMCOR Group
     "POWL":  {"sma": 100, "rsi": 45},   # Powell Industries
     "PWR":   {"sma": 100, "rsi": 45},   # Quanta Services
-    "JCI":   {"sma": 100, "rsi": 45},   # Johnson Controls
 }
 
 # 🔥 HIGH-BETA / Tactical (SMA-30, RSI≤35) – Short-term tactical trades
@@ -123,12 +119,8 @@ UTILITIES_BASKET = {
 DATA_CENTER_BASKET = {
     "PWR":   {"sma": 100, "rsi": 45},     # Quanta Services
     "EME":   {"sma": 100, "rsi": 45},     # EMCOR Group
-    "CAT":   {"sma": 100, "rsi": 45},     # Caterpillar
-    "CMI":   {"sma": 100, "rsi": 45},     # Cummins
     "ETN":   {"sma": 100, "rsi": 45},     # Eaton
     "POWL":  {"sma": 100, "rsi": 45},     # Powell Industries
-    "JCI":   {"sma": 100, "rsi": 45},     # Johnson Controls
-    "URI":   {"sma": 100, "rsi": 45},     # United Rentals
     "STRL":  {"sma": 100, "rsi": 45},     # Sterling Infrastructure
     "VRT":   {"sma": 100, "rsi": 45},     # Vertiv Holdings
 }

--- a/daily/generate_daily_email.py
+++ b/daily/generate_daily_email.py
@@ -54,7 +54,7 @@ def check_exit_signals():
             sma_period = "50"  # Default
             if row['Ticker'] in [
                 # Thematic sleeve (SMA-100) + Finimize basket tickers
-                'URNM.L', 'XYL', 'LEU', 'SMR', 'STRL', 'URI', 'CAT', 'VRT', 'ETN', 'CMI', 'EME', 'POWL', 'PWR', 'JCI',
+                'URNM.L', 'XYL', 'LEU', 'SMR', 'STRL', 'VRT', 'ETN', 'EME', 'POWL', 'PWR',
                 # Nuclear basket
                 'OKLO', 'UU',
                 # Utilities basket


### PR DESCRIPTION
## Summary
- Remove tickers URI, CAT, JCI, CMI from the Finimize Data Center Portfolio
- Remove same tickers from THEMATIC_RULES and exit signal notification list
- Data Center Portfolio now contains 6 tickers: PWR, EME, ETN, POWL, STRL, VRT

## Test plan
- [ ] Merge to main and trigger the Daily Screen workflow manually
- [ ] Verify the removed tickers no longer appear in the generated daily_screen.html

https://claude.ai/code/session_01Tvj4AqLK5ya5qFpBE5n8c1