### PR TITLE
Add ECJ, FIX, PRY, SU to data center portfolio

### DIFF
--- a/daily/daily_screen.py
+++ b/daily/daily_screen.py
@@ -31,6 +31,10 @@ THEMATIC_RULES = {
     "EME":   {"sma": 100, "rsi": 45},   # EMCOR Group
     "POWL":  {"sma": 100, "rsi": 45},   # Powell Industries
     "PWR":   {"sma": 100, "rsi": 45},   # Quanta Services
+    "ECJ":   {"sma": 100, "rsi": 45},   # Ecolab
+    "FIX":   {"sma": 100, "rsi": 45},   # Comfort Systems USA
+    "PRY":   {"sma": 100, "rsi": 45},   # Prysmian
+    "SU":    {"sma": 100, "rsi": 45},   # Schneider Electric
 }
 
 # 🔥 HIGH-BETA / Tactical (SMA-30, RSI≤35) – Short-term tactical trades
@@ -123,6 +127,10 @@ DATA_CENTER_BASKET = {
     "POWL":  {"sma": 100, "rsi": 45},     # Powell Industries
     "STRL":  {"sma": 100, "rsi": 45},     # Sterling Infrastructure
     "VRT":   {"sma": 100, "rsi": 45},     # Vertiv Holdings
+    "ECJ":   {"sma": 100, "rsi": 45},     # Ecolab
+    "FIX":   {"sma": 100, "rsi": 45},     # Comfort Systems USA
+    "PRY":   {"sma": 100, "rsi": 45},     # Prysmian
+    "SU":    {"sma": 100, "rsi": 45},     # Schneider Electric
 }
 
 WATER_BASKET = {

--- a/daily/generate_daily_email.py
+++ b/daily/generate_daily_email.py
@@ -54,7 +54,7 @@ def check_exit_signals():
             sma_period = "50"  # Default
             if row['Ticker'] in [
                 # Thematic sleeve (SMA-100) + Finimize basket tickers
-                'URNM.L', 'XYL', 'LEU', 'SMR', 'STRL', 'VRT', 'ETN', 'EME', 'POWL', 'PWR',
+                'URNM.L', 'XYL', 'LEU', 'SMR', 'STRL', 'VRT', 'ETN', 'EME', 'POWL', 'PWR', 'ECJ', 'FIX', 'PRY', 'SU',
                 # Nuclear basket
                 'OKLO', 'UU',
                 # Utilities basket


### PR DESCRIPTION
## Summary
- Add ECJ (Ecolab), FIX (Comfort Systems USA), PRY (Prysmian), SU (Schneider Electric) to the Finimize Data Center Portfolio
- Added to DATA_CENTER_BASKET, THEMATIC_RULES, and exit signal notification list

https://claude.ai/code/session_01Tvj4AqLK5ya5qFpBE5n8c1