### PR TITLE
Add IXUA, WSML, VJPA ETFs to Established tier

### DIFF
--- a/daily/daily_screen.py
+++ b/daily/daily_screen.py
@@ -95,6 +95,9 @@ ESTABLISHED_RULES = {
     "COST":   {"sma": 50, "rsi": 40},   # Costco Wholesale – NASDAQ
     "GOOGL":  {"sma": 50, "rsi": 40},   # Alphabet Inc. – NASDAQ
     "G2X":    {"sma": 50, "rsi": 40},   # VanEck Gold Miners UCITS ETF – Xetra
+    "IXUA":   {"sma": 50, "rsi": 40},   # iShares MSCI World ex-USA UCITS ETF – LSE
+    "WSML":   {"sma": 50, "rsi": 40},   # iShares MSCI World Small Cap UCITS ETF – LSE
+    "VJPA":   {"sma": 50, "rsi": 40},   # Vanguard FTSE Japan UCITS ETF – LSE
     "NU":     {"sma": 50, "rsi": 40},   # Nu Holdings (Nubank) – NYSE
     "RYCEY":  {"sma": 50, "rsi": 40},   # Rolls-Royce Holdings – US OTC ADR
     "XLU":    {"sma": 50, "rsi": 40},   # Utilities Select Sector SPDR ETF
@@ -217,6 +220,9 @@ ALIAS = {
     "FLXK": "FLXK.DE",   # Franklin FTSE Korea UCITS ETF – Xetra
     "THEON": "THEON.AS",  # Theon International – Euronext Amsterdam
     "G2X":  "G2X.DE",    # VanEck Gold Miners UCITS ETF – Xetra
+    "IXUA": "IXUA.L",   # iShares MSCI World ex-USA UCITS ETF – LSE (GBp)
+    "WSML": "WSML.L",   # iShares MSCI World Small Cap UCITS ETF – LSE (GBp)
+    "VJPA": "VJPA.L",   # Vanguard FTSE Japan UCITS ETF – LSE (GBp)
     "ASML": "ASML",      # ASML Holding
     "NTDOY": "NTDOY",    # Nintendo
     "PGR":  "PGR",       # Progressive Corporation
@@ -224,7 +230,7 @@ ALIAS = {
 }
 
 # ETFs / trusts with no earnings → auto-pass valuation
-ETF_SET = {"G2X"}
+ETF_SET = {"G2X", "IXUA", "WSML", "VJPA"}
 # Established stocks that should bypass valuation filter
 ESTABLISHED_BYPASS_VAL = {"AAPL", "LSEG"}
 

--- a/daily/rulebook.py
+++ b/daily/rulebook.py
@@ -49,4 +49,7 @@ RULES = {
     "BRYN":   {"sma": 50, "rsi": 40},
     "AAPL":   {"sma": 50, "rsi": 40},
     "G2X":    {"sma": 50, "rsi": 40},   # VanEck Gold Miners UCITS ETF – Xetra
-} 
+    "IXUA":   {"sma": 50, "rsi": 40},   # iShares MSCI World ex-USA UCITS ETF – LSE
+    "WSML":   {"sma": 50, "rsi": 40},   # iShares MSCI World Small Cap UCITS ETF – LSE
+    "VJPA":   {"sma": 50, "rsi": 40},   # Vanguard FTSE Japan UCITS ETF – LSE
+}


### PR DESCRIPTION
## Summary
- Added iShares MSCI World ex-USA UCITS ETF (IXUA.L) to Established tier
- Added iShares MSCI World Small Cap UCITS ETF (WSML.L) to Established tier
- Added Vanguard FTSE Japan UCITS ETF (VJPA.L) to Established tier
- All three added to ETF_SET to bypass valuation filter (SMA-50, RSI≤40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)