### PR TITLE
Harden normalize_row against Yahoo info failures

### DIFF
--- a/daily/daily_screen.py
+++ b/daily/daily_screen.py
@@ -252,7 +252,10 @@ def gbx_gbp_eur(price: float, currency: str) -> float:
     """
     if currency not in ("GBX", "GBp", "GBP"):
         return price                        # already native
-    gbp_eur = yf.Ticker("GBPEUR=X").fast_info["last_price"]
+    try:
+        gbp_eur = yf.Ticker("GBPEUR=X").fast_info["last_price"]
+    except Exception:
+        return price                        # FX lookup failed; leave unchanged
     if currency in ("GBX", "GBp"):
         price = price / 100                # to pounds first
     return price * gbp_eur
@@ -264,7 +267,15 @@ def normalize_row(row):
     """
     ticker = row["Ticker"]
     yahoo_symbol = ALIAS.get(ticker, ticker)
-    currency = yf.Ticker(yahoo_symbol).info.get("currency", "EUR")
+    # Only LSE-listed names may quote in GBX/GBP; skip the network call otherwise.
+    if not yahoo_symbol.endswith(".L"):
+        return row
+    try:
+        currency = yf.Ticker(yahoo_symbol).info.get("currency", "EUR")
+    except Exception:
+        return row                          # Yahoo info failed; leave row unchanged
+    if not isinstance(row["Close"], (int, float)):
+        return row
     row["Close"] = gbx_gbp_eur(row["Close"], currency)
     row["SMA"]   = gbx_gbp_eur(row["SMA"],   currency)
     return row


### PR DESCRIPTION
## Summary
The Daily Screen workflow crashed at `table.apply(normalize_row)` because `yf.Ticker(...).info` raised `JSONDecodeError` when Yahoo returned HTTP 400 mid-run (visible in the failed workflow log).

- Skip the `.info` network call entirely for tickers that don't end in `.L` — only LSE listings can quote in GBX/GBP, and the existing code called Yahoo once per row regardless.
- Wrap `.info` and the GBP/EUR FX lookup in `try/except`, falling back to the unchanged row/price when Yahoo hiccups.
- Bail out of conversion when `Close` is non-numeric (the SKIP rows).

## Test plan
- [ ] Re-trigger Daily Screen workflow on `main` and confirm `daily/daily_screen.py` completes and writes `docs/daily_screen.html` + `.csv`.

https://claude.ai/code/session_017JJpUWrnAv4b6bLzv8AzNv

---
_Generated by [Claude Code](https://claude.ai/code/session_017JJpUWrnAv4b6bLzv8AzNv)_