### PR TITLE
Remove VST and GTT from daily screen

### DIFF
--- a/daily/daily_screen.py
+++ b/daily/daily_screen.py
@@ -51,7 +51,6 @@ HIGH_BETA_RULES = {
     "NBIS":   {"sma": 30, "rsi": 35},   # Nebius – added 30 Jul 2025
     "IDR.MC": {"sma": 30, "rsi": 35},   # Indra Sistemas – Madrid exchange
     "9660":   {"sma": 30, "rsi": 35},   # Horizon Robotics – HKEX code 9660
-    "GTT":    {"sma": 30, "rsi": 35},   # Gaztransport & Technigaz – ~$4B mcap
     "6324":   {"sma": 30, "rsi": 35},   # Harmonic Drive Systems – ~$2B mcap
     # Finimize single-stock picks (market cap < $10B → High-Beta)
     "FLXK":   {"sma": 30, "rsi": 35},   # Franklin FTSE Korea UCITS ETF – Xetra
@@ -110,7 +109,6 @@ NUCLEAR_BASKET = {
 }
 
 UTILITIES_BASKET = {
-    "VST":  {"sma": 100, "rsi": 45},      # Vistra Corp
     "CEG":  {"sma": 100, "rsi": 45},      # Constellation Energy
     "NEE":  {"sma": 100, "rsi": 45},      # NextEra Energy
 }
@@ -180,7 +178,6 @@ ALIAS = {
     "6324": "6324.T",    # Harmonic Drive Systems – Tokyo
     "FGR":  "FGR.PA",    # Eiffage S.A. – Euronext Paris
     "AI":   "AI.PA",     # Air Liquide – Euronext Paris
-    "GTT":  "GTT.PA",    # Gaztransport & Technigaz – Euronext Paris
     "9660": "9660.HK",   # Horizon Robotics – Hong Kong (Yahoo symbol)
     "ALFA.ST": "ALFA.ST", # Alfa Laval – Stockholm
     "FLXK":  "FLXK.L",   # Franklin FTSE Korea UCITS ETF – London

--- a/daily/generate_daily_email.py
+++ b/daily/generate_daily_email.py
@@ -57,8 +57,6 @@ def check_exit_signals():
                 'URNM.L', 'XYL', 'LEU', 'SMR', 'STRL', 'VRT', 'ETN', 'EME', 'POWL', 'PWR', 'ECJ.F', 'FIX', 'PRY.MI', 'SU.PA',
                 # Nuclear basket
                 'OKLO', 'UU',
-                # Utilities basket
-                'VST',
                 # China AI basket
                 '9698', '3690', '1810', 'XPEV', 'LI',
                 # Grid Modernization basket
@@ -68,7 +66,7 @@ def check_exit_signals():
             elif row['Ticker'] in [
                 # High-Beta sleeve (SMA-30)
                 'ATLX', 'BMI', 'EOSE', 'GWH', 'H4N.F', 'KD', 'SANA', 'TMDX',
-                'NBIS', 'IDR.MC', '9660', 'GTT', '6324', 'FLXK', 'HUMN'
+                'NBIS', 'IDR.MC', '9660', '6324', 'FLXK', 'HUMN'
             ]:
                 sma_period = "30"   # High-Beta
             


### PR DESCRIPTION
## Summary
- Drop `VST` from `UTILITIES_BASKET` and the Thematic SMA-100 list in `generate_daily_email.py`.
- Drop `GTT` from `HIGH_BETA_RULES`, its alias entry, and the High-Beta SMA-30 list in `generate_daily_email.py`.

## Test plan
- [ ] Re-trigger Daily Screen workflow on `main` and confirm VST and GTT no longer appear.

https://claude.ai/code/session_017JJpUWrnAv4b6bLzv8AzNv

---
_Generated by [Claude Code](https://claude.ai/code/session_017JJpUWrnAv4b6bLzv8AzNv)_